### PR TITLE
Fix broken links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ Learn more about White Whale Protocol, its core smart contracts, and Python SDK.
 
 * Learn more about the [Governance](protocol/governance/Governance-Overview.md).
 * Read up on the specifics of each contract such as the [Stablecoin Vault](Smart/../Smart-Contracts/Stablecoin-Vault.md). 
-* Check out the [User Guide](user-guide/README.md).
+* Check out the [User Guide](user-guide/index.md).
 
 ## Community
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ You can access the White Whale platform through the official [Web App](user-guid
 Deposited tokens are represented by vault tokens (vUST, vLUNA, ...). These tokens are redeemable for the initial deposit along with it's accrued interest, making these tokens auto-compouning. White Whale vaults are structured to provide depositors with:
 
 * **High, stable deposit yields** powered by the [Anchor Protocol](https://anchorprotocol.com)
-* **Arbitrage Exposure** through [White Whale abitrage](protocol/whale-token/Arbitrage_exposure.md) of stablecoin deposits
+* **Arbitrage Exposure** through [White Whale abitrage](protocol/Arb-Vaults/Arbitrage_Vaults.md) of stablecoin deposits
 
 White Whale is an open, permissionless arbitrage protocol, meaning that any third-party application is free to connect and earn interest without restrictions.
 Furthermore, all arbitrage contracts are publicly callable. 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ description: Welcome to the White Whale documentation site.
 
 Welcome to the White Whale Protocol's documentation site.
 
-You can access the White Whale platform through the official [Web App](user-guide/webapp/).
+You can access the White Whale platform through the official [Web App](user-guide/WebApp.md).
 
 ## What is White Whale?
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,0 +1,12 @@
+---
+description: Welcome to the White Whale User Guides
+---
+
+# User Guides
+
+* White Whale [Liquidity](Liquidity.md)
+* Voting on [Governance Proposals](Proposals-Voting.md)
+* [Staking](Staking.md) WHALE tokens
+* [Swapping](Swap.md) WHALE tokens
+* Depositing in to White Whale [Vaults](Vaults.md)
+* Using the official [White Whale frontend interface](WebApp.md)


### PR DESCRIPTION
Found a couple of broken links in the main documentation page. This PR fixes those. In addition, the link and organizational structure of the user-guides section was completely broken. I've added an `index.md` to that folder containing a basic list of the guides within and fixed the link on the main page appropriately.